### PR TITLE
Fix external outline not being added to stack if not masking

### DIFF
--- a/lib/_gather-layers.js
+++ b/lib/_gather-layers.js
@@ -80,14 +80,20 @@ module.exports = function(element, idPrefix, layers, drills, outline, maskWithOu
   var outlineId
 
   // add the outline to defs if it's not defined externally or if we're using it to clip
-  if (outline && (!outline.externalId || maskWithOutline)) {
-    outlineId = getUniqueId(outline.type)
-    defs.push(wrapLayer(
-      element,
-      outlineId,
-      outline.converter,
-      getScale(units, outline.converter.units),
-      maskWithOutline ? 'clipPath' : 'g'))
+  if (outline) {
+    if (outline.externalId && !maskWithOutline) {
+      outlineId = outline.externalId
+    }
+    else {
+      outlineId = getUniqueId(outline.type)
+
+      defs.push(wrapLayer(
+        element,
+        outlineId,
+        outline.converter,
+        getScale(units, outline.converter.units),
+        maskWithOutline ? 'clipPath' : 'g'))
+    }
   }
 
   return {

--- a/test/stack-layers_test.js
+++ b/test/stack-layers_test.js
@@ -440,5 +440,26 @@ describe('stack layers function', function() {
         'use',
         sinon.match.has('xlink:href', '#id_top_drl2'))
     })
+
+    it('should use external drill id for use if not masking', function() {
+      outline.externalId = 'baz'
+
+      var result = stackLayers(element, 'id', 'top', layers, drills, outline)
+      var values = expectXmlNodes(element, [
+        {
+          tag: 'use',
+          attr: {
+            'xlink:href': '#baz',
+            class: 'id_out',
+            fill: 'currentColor',
+            stroke: 'currentColor'
+          }
+        }
+      ])
+
+      delete outline.externalId
+
+      expect(result.layer.slice(-1)).to.eql(values)      
+    })
   })
 })


### PR DESCRIPTION
The external id feature has a bug where if an outline with an external ID is used, but maskWithOutline is set to false, the outline will not be applied (printed as black lines on the board)
