### PR TITLE
Inkscape compatibility

### DIFF
--- a/lib/_board-style.js
+++ b/lib/_board-style.js
@@ -32,7 +32,7 @@ module.exports = function boardStyle(element, prefix, side, layerColors) {
     colorClass('out')
   ]
 
-  var stylesString = '/* <![CDATA[ */' + styles.join('\n') + '/* ]]> */'
+  var stylesString = styles.join('\n')
 
   return element('style', {}, [stylesString])
 }

--- a/lib/_board-style.js
+++ b/lib/_board-style.js
@@ -1,5 +1,6 @@
 // function to generate a board style node
 'use strict'
+var colorString = require('color-string')
 
 module.exports = function boardStyle(element, prefix, side, layerColors) {
   var colors = {
@@ -18,6 +19,17 @@ module.exports = function boardStyle(element, prefix, side, layerColors) {
 
   var colorClass = function(layer) {
     var style = 'color: ' + colors[layer] + ';'
+
+    // convert rgba to hex and opacity for inkscape compatibility
+    if (/rgba/.test(colors[layer])) {
+      var rgba = colorString.get.rgb(colors[layer])
+
+      if (rgba) {
+        var hex = colorString.to.hex(rgba)
+
+        style = 'color: ' + hex + '; opacity: ' + rgba[3] + ';'
+      }
+    }
 
     return '.' + prefix + layer + ' {' + style + '}'
   }

--- a/lib/stack-layers.js
+++ b/lib/stack-layers.js
@@ -88,7 +88,7 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
     var cfMaskId = idPrefix + 'cf-mask'
     var cfMaskAttr = {id: cfMaskId, fill: '#fff', stroke: '#fff'}
     var cfMaskShape = smLayerId
-      ? [useLayer(element, smLayerId)]
+      ? [element('use', {'xlink:href': '#' + smLayerId, fill: '#fff', stroke: '#fff'})]
       : [createRect(element, box)]
     var cfMaskGroup = [element('g', {}, cfMaskShape)]
 
@@ -105,7 +105,7 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
     var smMaskAttr = {id: smMaskId, fill: '#000', stroke: '#000'}
     var smMaskShape = [
       createRect(element, box, '#fff'),
-      useLayer(element, smLayerId)
+      element('use', {'xlink:href': '#' + smLayerId, fill: '#000', stroke: '#000'})
     ]
     var smMaskGroup = [element('g', {}, smMaskShape)]
 

--- a/lib/stack-layers.js
+++ b/lib/stack-layers.js
@@ -55,7 +55,9 @@ var mechMask = function(element, id, box, drills) {
 
   children.unshift(createRect(element, box, '#fff'))
 
-  return element('mask', maskAttr, children)
+  var group = [element('g', {}, children)]
+
+  return element('mask', maskAttr, group)
 }
 
 module.exports = function(element, id, side, layers, drills, outline, useOutline) {
@@ -88,8 +90,9 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
     var cfMaskShape = smLayerId
       ? [useLayer(element, smLayerId)]
       : [createRect(element, box)]
+    var cfMaskGroup = [element('g', {}, cfMaskShape)]
 
-    defs.push(element('mask', cfMaskAttr, cfMaskShape))
+    defs.push(element('mask', cfMaskAttr, cfMaskGroup))
     layer.push(useLayer(element, cuLayerId, classPrefix + 'cu'))
     layer.push(useLayer(element, cuLayerId, classPrefix + 'cf', cfMaskId))
   }
@@ -104,8 +107,9 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
       createRect(element, box, '#fff'),
       useLayer(element, smLayerId)
     ]
+    var smMaskGroup = [element('g', {}, smMaskShape)]
 
-    defs.push(element('mask', smMaskAttr, smMaskShape))
+    defs.push(element('mask', smMaskAttr, smMaskGroup))
 
     // add the layer that gets masked
     var smGroupAttr = {mask: 'url(#' + smMaskId + ')'}

--- a/lib/stack-layers.js
+++ b/lib/stack-layers.js
@@ -87,7 +87,7 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
   if (cuLayerId) {
     var cfMaskId = idPrefix + 'cf-mask'
     var cfMaskShape = smLayerId
-      ? [element('use', {'xlink:href': '#' + smLayerId})]
+      ? [useLayer(element, smLayerId)]
       : [createRect(element, box)]
     var cfMaskGroupAttr =  {fill: '#fff', stroke: '#fff'}
     var cfMaskGroup = [element('g', cfMaskGroupAttr, cfMaskShape)]
@@ -104,7 +104,7 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
     var smMaskId = idPrefix + 'sm-mask'
     var smMaskShape = [
       createRect(element, box, '#fff'),
-      element('use', {'xlink:href': '#' + smLayerId})
+      useLayer(element, smLayerId)
     ]
     var smMaskGroupAtrr = {fill: '#000', stroke: '#000'}
     var smMaskGroup = [element('g', smMaskGroupAtrr, smMaskShape)]

--- a/lib/stack-layers.js
+++ b/lib/stack-layers.js
@@ -48,14 +48,14 @@ var createRect = function(element, box, fill, className) {
 }
 
 var mechMask = function(element, id, box, drills) {
-  var maskAttr = {id: id, fill: '#000', stroke: '#000'}
+  var maskAttr = {id: id}
   var children = drills.map(function(layer) {
     return useLayer(element, layer.id)
   })
 
   children.unshift(createRect(element, box, '#fff'))
 
-  var group = [element('g', {}, children)]
+  var group = [element('g', {fill: '#000', stroke: '#000'}, children)]
 
   return element('mask', maskAttr, group)
 }
@@ -86,11 +86,11 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
   // add copper and copper finish
   if (cuLayerId) {
     var cfMaskId = idPrefix + 'cf-mask'
-    var cfMaskAttr = {id: cfMaskId, fill: '#fff', stroke: '#fff'}
+    var cfMaskAttr = {id: cfMaskId}
     var cfMaskShape = smLayerId
-      ? [element('use', {'xlink:href': '#' + smLayerId, fill: '#fff', stroke: '#fff'})]
+      ? [element('use', {'xlink:href': '#' + smLayerId})]
       : [createRect(element, box)]
-    var cfMaskGroup = [element('g', {}, cfMaskShape)]
+    var cfMaskGroup = [element('g', {fill: '#fff', stroke: '#fff'}, cfMaskShape)]
 
     defs.push(element('mask', cfMaskAttr, cfMaskGroup))
     layer.push(useLayer(element, cuLayerId, classPrefix + 'cu'))
@@ -102,12 +102,12 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
   if (smLayerId) {
     // solder mask is... a mask, so mask it
     var smMaskId = idPrefix + 'sm-mask'
-    var smMaskAttr = {id: smMaskId, fill: '#000', stroke: '#000'}
+    var smMaskAttr = {id: smMaskId}
     var smMaskShape = [
       createRect(element, box, '#fff'),
-      element('use', {'xlink:href': '#' + smLayerId, fill: '#000', stroke: '#000'})
+      element('use', {'xlink:href': '#' + smLayerId})
     ]
-    var smMaskGroup = [element('g', {}, smMaskShape)]
+    var smMaskGroup = [element('g', {fill: '#000', stroke: '#000'}, smMaskShape)]
 
     defs.push(element('mask', smMaskAttr, smMaskGroup))
 

--- a/lib/stack-layers.js
+++ b/lib/stack-layers.js
@@ -48,16 +48,16 @@ var createRect = function(element, box, fill, className) {
 }
 
 var mechMask = function(element, id, box, drills) {
-  var maskAttr = {id: id}
   var children = drills.map(function(layer) {
     return useLayer(element, layer.id)
   })
 
   children.unshift(createRect(element, box, '#fff'))
 
-  var group = [element('g', {fill: '#000', stroke: '#000'}, children)]
+  var groupAttr = {fill: '#000', stroke: '#000'}
+  var group = [element('g', groupAttr, children)]
 
-  return element('mask', maskAttr, group)
+  return element('mask', {id: id}, group)
 }
 
 module.exports = function(element, id, side, layers, drills, outline, useOutline) {
@@ -86,13 +86,13 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
   // add copper and copper finish
   if (cuLayerId) {
     var cfMaskId = idPrefix + 'cf-mask'
-    var cfMaskAttr = {id: cfMaskId}
     var cfMaskShape = smLayerId
       ? [element('use', {'xlink:href': '#' + smLayerId})]
       : [createRect(element, box)]
-    var cfMaskGroup = [element('g', {fill: '#fff', stroke: '#fff'}, cfMaskShape)]
+    var cfMaskGroupAttr =  {fill: '#fff', stroke: '#fff'}
+    var cfMaskGroup = [element('g', cfMaskGroupAttr, cfMaskShape)]
 
-    defs.push(element('mask', cfMaskAttr, cfMaskGroup))
+    defs.push(element('mask', {id: cfMaskId}, cfMaskGroup))
     layer.push(useLayer(element, cuLayerId, classPrefix + 'cu'))
     layer.push(useLayer(element, cuLayerId, classPrefix + 'cf', cfMaskId))
   }
@@ -102,14 +102,14 @@ module.exports = function(element, id, side, layers, drills, outline, useOutline
   if (smLayerId) {
     // solder mask is... a mask, so mask it
     var smMaskId = idPrefix + 'sm-mask'
-    var smMaskAttr = {id: smMaskId}
     var smMaskShape = [
       createRect(element, box, '#fff'),
       element('use', {'xlink:href': '#' + smLayerId})
     ]
-    var smMaskGroup = [element('g', {fill: '#000', stroke: '#000'}, smMaskShape)]
+    var smMaskGroupAtrr = {fill: '#000', stroke: '#000'}
+    var smMaskGroup = [element('g', smMaskGroupAtrr, smMaskShape)]
 
-    defs.push(element('mask', smMaskAttr, smMaskGroup))
+    defs.push(element('mask', {id: smMaskId}, smMaskGroup))
 
     // add the layer that gets masked
     var smGroupAttr = {mask: 'url(#' + smMaskId + ')'}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "zuul-ngrok": "^4.0.0"
   },
   "dependencies": {
+    "color-string": "^1.4.0",
     "lodash.isstring": "^4.0.1",
     "viewbox": "^1.0.0",
     "xml-element-string": "^1.0.0"

--- a/test/pcb-stackup_test.js
+++ b/test/pcb-stackup_test.js
@@ -32,7 +32,7 @@ var converter = function() {
   }
 }
 
-var EXPECTED_DEFAULT_STYLE = '/* <![CDATA[ */' + [
+var EXPECTED_DEFAULT_STYLE = [
   '.foobar_fr4 {color: #666;}',
   '.foobar_cu {color: #ccc;}',
   '.foobar_cf {color: #c93;}',
@@ -40,7 +40,7 @@ var EXPECTED_DEFAULT_STYLE = '/* <![CDATA[ */' + [
   '.foobar_ss {color: #fff;}',
   '.foobar_sp {color: #999;}',
   '.foobar_out {color: #000;}'
-].join('\n') + '/* ]]> */'
+].join('\n')
 
 describe('pcb stackup function', function() {
   beforeEach(function() {
@@ -117,7 +117,7 @@ describe('pcb stackup function', function() {
       color: {cu: '#123', cf: '#456', sp: '#789'}
     }
     var result = pcbStackupCore([], options)
-    var expectedStyle = '/* <![CDATA[ */' + [
+    var expectedStyle = [
       '.foobar_fr4 {color: #666;}',
       '.foobar_cu {color: #123;}',
       '.foobar_cf {color: #456;}',
@@ -125,7 +125,7 @@ describe('pcb stackup function', function() {
       '.foobar_ss {color: #fff;}',
       '.foobar_sp {color: #789;}',
       '.foobar_out {color: #000;}'
-    ].join('\n') + '/* ]]> */'
+    ].join('\n')
 
     var styleSpy = element.withArgs('style', {}, [expectedStyle])
 

--- a/test/pcb-stackup_test.js
+++ b/test/pcb-stackup_test.js
@@ -36,7 +36,7 @@ var EXPECTED_DEFAULT_STYLE = [
   '.foobar_fr4 {color: #666;}',
   '.foobar_cu {color: #ccc;}',
   '.foobar_cf {color: #c93;}',
-  '.foobar_sm {color: rgba(00, 66, 00, 0.75);}',
+  '.foobar_sm {color: #004200; opacity: 0.75;}',
   '.foobar_ss {color: #fff;}',
   '.foobar_sp {color: #999;}',
   '.foobar_out {color: #000;}'
@@ -121,7 +121,7 @@ describe('pcb stackup function', function() {
       '.foobar_fr4 {color: #666;}',
       '.foobar_cu {color: #123;}',
       '.foobar_cf {color: #456;}',
-      '.foobar_sm {color: rgba(00, 66, 00, 0.75);}',
+      '.foobar_sm {color: #004200; opacity: 0.75;}',
       '.foobar_ss {color: #fff;}',
       '.foobar_sp {color: #789;}',
       '.foobar_out {color: #000;}'

--- a/test/stack-layers_test.js
+++ b/test/stack-layers_test.js
@@ -211,14 +211,15 @@ describe('stack layers function', function() {
         {tag: 'rect', attr: {x: -50, y: -50, width: 1100, height: 1100, fill: '#fff'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl1'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl2'}},
+        {tag: 'g', attr: {}, children: [0, 1, 2]},
         {
           tag: 'mask',
           attr: {id: 'id_top_mech-mask', fill: '#000', stroke: '#000'},
-          children: [0, 1, 2]
+          children: [3]
         }
       ])
 
-      expect(result.defs).to.contain(values[3])
+      expect(result.defs).to.contain(values[4])
     })
 
     it('should handle being told to use the outline when it is missing', function() {
@@ -227,14 +228,15 @@ describe('stack layers function', function() {
         {tag: 'rect', attr: {x: -10, y: -10, width: 1020, height: 1210, fill: '#fff'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl1'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl2'}},
+        {tag: 'g', attr: {}, children: [0, 1, 2]},
         {
           tag: 'mask',
           attr: {id: 'id_top_mech-mask', fill: '#000', stroke: '#000'},
-          children: [0, 1, 2]
+          children: [3]
         }
       ])
 
-      expect(result.defs).to.contain(values[3])
+      expect(result.defs).to.contain(values[4])
     })
   })
 
@@ -263,10 +265,11 @@ describe('stack layers function', function() {
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
         {tag: 'rect', attr: {x: 0, y: 0, width: 1000, height: 1000}},
+        {tag: 'g', attr: {}, children: [0]},
         {
           tag: 'mask',
           attr: {id: 'id_top_cf-mask', fill: '#fff', stroke: '#fff'},
-          children: [0]
+          children: [1]
         },
         {
           tag: 'use',
@@ -289,8 +292,8 @@ describe('stack layers function', function() {
         }
       ])
 
-      expect(result.defs.slice(-1)).to.eql([values[1]])
-      expect(result.layer.slice(-2)).to.eql([values[2], values[3]])
+      expect(result.defs.slice(-1)).to.eql([values[2]])
+      expect(result.layer.slice(-2)).to.eql([values[3], values[4]])
     })
 
     it('should use the soldermask to mask the copper finish if it exists', function() {
@@ -301,14 +304,15 @@ describe('stack layers function', function() {
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
         {tag: 'use', attr: {'xlink:href': '#id_top_sm'}},
+        {tag: 'g', attr: {}, children: [0]},
         {
           tag: 'mask',
           attr: {id: 'id_top_cf-mask', fill: '#fff', stroke: '#fff'},
-          children: [0]
+          children: [1]
         }
       ])
 
-      expect(result.defs).to.contain(values[1])
+      expect(result.defs).to.contain(values[2])
     })
 
     it('should add the soldermask', function() {
@@ -319,19 +323,20 @@ describe('stack layers function', function() {
       var values = expectXmlNodes(element, [
         {tag: 'rect', attr: {x: 0, y: 0, width: 500, height: 500, fill: '#fff'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_sm'}},
+        {tag: 'g', attr: {}, children: [0, 1]},
         {
           tag: 'mask',
           attr: {id: 'id_top_sm-mask', fill: '#000', stroke: '#000'},
-          children: [0, 1]},
+          children: [2]},
         {
           tag: 'rect',
           attr: {x: 0, y: 0, width: 500, height: 500, class: 'id_sm', fill: 'currentColor'}
         },
-        {tag: 'g', attr: {mask: 'url(#id_top_sm-mask)'}, children: [3]}
+        {tag: 'g', attr: {mask: 'url(#id_top_sm-mask)'}, children: [4]}
       ])
 
-      expect(result.defs).to.contain(values[2])
-      expect(result.layer.slice(-1)).to.eql([values[4]])
+      expect(result.defs).to.contain(values[3])
+      expect(result.layer.slice(-1)).to.eql([values[5]])
     })
 
     it('should add silkscreen when there is a mask and a silk', function() {
@@ -459,7 +464,7 @@ describe('stack layers function', function() {
 
       delete outline.externalId
 
-      expect(result.layer.slice(-1)).to.eql(values)      
+      expect(result.layer.slice(-1)).to.eql(values)
     })
   })
 })

--- a/test/stack-layers_test.js
+++ b/test/stack-layers_test.js
@@ -211,10 +211,10 @@ describe('stack layers function', function() {
         {tag: 'rect', attr: {x: -50, y: -50, width: 1100, height: 1100, fill: '#fff'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl1'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl2'}},
-        {tag: 'g', attr: {}, children: [0, 1, 2]},
+        {tag: 'g', attr: {fill: '#000', stroke: '#000'}, children: [0, 1, 2]},
         {
           tag: 'mask',
-          attr: {id: 'id_top_mech-mask', fill: '#000', stroke: '#000'},
+          attr: {id: 'id_top_mech-mask'},
           children: [3]
         }
       ])
@@ -228,10 +228,10 @@ describe('stack layers function', function() {
         {tag: 'rect', attr: {x: -10, y: -10, width: 1020, height: 1210, fill: '#fff'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl1'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drl2'}},
-        {tag: 'g', attr: {}, children: [0, 1, 2]},
+        {tag: 'g', attr: {fill: '#000', stroke: '#000'}, children: [0, 1, 2]},
         {
           tag: 'mask',
-          attr: {id: 'id_top_mech-mask', fill: '#000', stroke: '#000'},
+          attr: {id: 'id_top_mech-mask'},
           children: [3]
         }
       ])
@@ -265,10 +265,10 @@ describe('stack layers function', function() {
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
         {tag: 'rect', attr: {x: 0, y: 0, width: 1000, height: 1000}},
-        {tag: 'g', attr: {}, children: [0]},
+        {tag: 'g', attr: {fill: '#fff', stroke: '#fff'}, children: [0]},
         {
           tag: 'mask',
-          attr: {id: 'id_top_cf-mask', fill: '#fff', stroke: '#fff'},
+          attr: {id: 'id_top_cf-mask'},
           children: [1]
         },
         {
@@ -303,11 +303,11 @@ describe('stack layers function', function() {
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
-        {tag: 'use', attr: {'xlink:href': '#id_top_sm', fill: '#fff', stroke: '#fff'}},
-        {tag: 'g', attr: {}, children: [0]},
+        {tag: 'use', attr: {'xlink:href': '#id_top_sm'}},
+        {tag: 'g', attr: {fill: '#fff', stroke: '#fff'}, children: [0]},
         {
           tag: 'mask',
-          attr: {id: 'id_top_cf-mask', fill: '#fff', stroke: '#fff'},
+          attr: {id: 'id_top_cf-mask'},
           children: [1]
         }
       ])
@@ -322,11 +322,11 @@ describe('stack layers function', function() {
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
         {tag: 'rect', attr: {x: 0, y: 0, width: 500, height: 500, fill: '#fff'}},
-        {tag: 'use', attr: {'xlink:href': '#id_top_sm', fill: '#000', stroke: '#000'}},
-        {tag: 'g', attr: {}, children: [0, 1]},
+        {tag: 'use', attr: {'xlink:href': '#id_top_sm'}},
+        {tag: 'g', attr: {fill: '#000', stroke: '#000'}, children: [0, 1]},
         {
           tag: 'mask',
-          attr: {id: 'id_top_sm-mask', fill: '#000', stroke: '#000'},
+          attr: {id: 'id_top_sm-mask'},
           children: [2]},
         {
           tag: 'rect',

--- a/test/stack-layers_test.js
+++ b/test/stack-layers_test.js
@@ -303,7 +303,7 @@ describe('stack layers function', function() {
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
-        {tag: 'use', attr: {'xlink:href': '#id_top_sm'}},
+        {tag: 'use', attr: {'xlink:href': '#id_top_sm', fill: '#fff', stroke: '#fff'}},
         {tag: 'g', attr: {}, children: [0]},
         {
           tag: 'mask',
@@ -322,7 +322,7 @@ describe('stack layers function', function() {
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
         {tag: 'rect', attr: {x: 0, y: 0, width: 500, height: 500, fill: '#fff'}},
-        {tag: 'use', attr: {'xlink:href': '#id_top_sm'}},
+        {tag: 'use', attr: {'xlink:href': '#id_top_sm', fill: '#000', stroke: '#000'}},
         {tag: 'g', attr: {}, children: [0, 1]},
         {
           tag: 'mask',


### PR DESCRIPTION
As discussed in https://github.com/tracespace/pcb-stackup/issues/29. 

I am not sure what to do about escaping XML characters as the escape sequences, e.g. ` &quot;`, have semi-colons in them which need to be escaped in CSS and I am not sure if the double escaping will work at all.

EDIT: Looks like the `<[!CDATA[` is ok _without comment tags_. Works ok without comments in latest Chromium and Firefox as well. Do you know where it might cause problems to put it in without the comments?